### PR TITLE
fix: parse_duration drops the days (d) unit

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -7,6 +7,7 @@ import re
 # Seconds per unit. Supported: weeks, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## What
Add the missing `d` (days) unit to parse_duration's unit table so day components are counted (86400s) instead of being silently dropped.

## Why
Closes #1 — parse_duration drops the days (d) unit

## How tested
Added unit tests for `1d` (86400) and `2d4h` (187200); the full suite (9 tests) passes via `python -m unittest discover -s tests`. Existing tests unchanged.

---
/claim #1
