### PR TITLE
fix: count days in parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
 }
 
-_TOKEN = re.compile(r"(\d+)([wdhms])")
+_UNIT_CHARS = "".join(re.escape(unit) for unit in _UNITS)
+_TOKEN = re.compile(rf"(\d+)([{_UNIT_CHARS}])")
 
 
 def parse_duration(text: str) -> int:

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,15 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined_with_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
+    def test_all_units_combined(self):
+        self.assertEqual(parse_duration("1w2d3h4m5s"), 788645)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
/claim #1

💳 Payment: USDC | 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2 | Base

## Summary
- Add the missing `d` unit to the duration unit table as 86400 seconds.
- Build token recognition from `_UNITS` so the regex and unit mapping cannot drift.
- Update the unit comment to include days.
- Add regression tests for `1d`, `2d4h`, and a full mixed-unit string.

## Tests
- `python -m unittest discover -s tests` -> 10 passing
- `python -m py_compile duration_utils.py tests/test_duration_utils.py` -> passed
- Clean venv install/import smoke check for `1d`, `2d4h`, and `1w2d3h4m5s` -> passed
- `git diff --check` -> passed

Closes #1