### PR TITLE
Fix parse_duration day unit handling

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("2d"), 172800)
+
+    def test_days_combined_with_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

- Add `d` to the duration unit table so day tokens are counted as `86400` seconds.
- Add regression tests for standalone and combined day durations.

## Verification

```text
C:\Users\zy\AppData\Local\Programs\Python\Python313\python.exe -m unittest discover -s tests

.........
Ran 9 tests in 0.001s
OK
```

Fixes #1

/claim #1
