### PR TITLE
fix: parse_duration now handles days (d) unit

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: days, weeks, hours, minutes, seconds.
 _UNITS = {
+    "d": 86400,
     "w": 604800,
     "h": 3600,
     "m": 60,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -4,6 +4,12 @@ from duration_utils import parse_duration
 
 
 class ParseDuration(unittest.TestCase):
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_and_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_hours(self):
         self.assertEqual(parse_duration("1h"), 3600)
 


### PR DESCRIPTION
## Summary

Added `d` (days) unit support to `parse_duration`. The `d` character was already accepted by the token regex but had no entry in `_UNITS`, causing `parse_duration('1d')` to return 0 instead of 86400.

## Changes
- Added `"d": 86400` to `_UNITS` in `duration_utils.py`
- Added test cases for days: `test_days` and `test_days_and_hours`

## Testing
```
1d -> 86400 seconds
2d4h -> 187200 seconds
```

Fixes the bug where `parse_duration` ignored the 'd' unit.