### PR TITLE
Fix parse_duration day unit handling

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -21,6 +22,7 @@ def parse_duration(text: str) -> int:
     Examples:
         parse_duration("1h30m") -> 5400
         parse_duration("1w")    -> 604800
+        parse_duration("1d")    -> 86400
 
     Raises ValueError on empty or malformed input.
     """

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,8 +16,14 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
+
+    def test_combined_with_days(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
 
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
# Fix parse_duration day-unit handling

Closes https://github.com/tine1117/oss-hunter-livefire/issues/1

## What changed

- Added `d` to `_UNITS` with `86400` seconds.
- Updated the docstring examples to include `parse_duration("1d")`.
- Added regression coverage for `1d` and `2d4h`.

## Verification

```text
python -m unittest

.........
----------------------------------------------------------------------
Ran 9 tests in 0.000s

OK
```
