### PR TITLE
fix: count the days (d) unit in parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -20,6 +21,7 @@ def parse_duration(text: str) -> int:
 
     Examples:
         parse_duration("1h30m") -> 5400
+        parse_duration("1d")    -> 86400
         parse_duration("1w")    -> 604800
 
     Raises ValueError on empty or malformed input.

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Problem

The token regex accepts `d` in `duration_utils.py` but the `_UNITS` mapping omits it, causing `parse_duration` to silently drop day-based components — `parse_duration("1d")` returns `0` instead of `86400`. The `_TOKEN` regex correctly tokenizes the `d` unit and the parser consumes the token, but the `unit in _UNITS` guard evaluates to `False`, so the value is never accumulated.

## Fix

- Added `"d": 86400` to the `_UNITS` mapping
- Updated the module docstring to list `d` among supported units and added a usage example
- Added two test cases: `test_days` (`1d` confirms 86400) and `test_days_combined` (`2d4h` confirms 187200)

## Verification

```
$ python -m unittest discover -s tests -v
Ran 9 tests in 0.001s

OK
```

Closes #1.