### PR TITLE
fix: add days (d) unit support to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -13,6 +13,12 @@ class ParseDuration(unittest.TestCase):
     def test_seconds(self):
         self.assertEqual(parse_duration("45s"), 45)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 


### PR DESCRIPTION
The `parse_duration` function silently ignored the `d` (days) unit even though:

1. The token regex `_TOKEN` already accepted `d` as a valid suffix
2. The README explicitly listed `d` as a supported unit

This caused inputs like `"1d"` to return `0` instead of `86400`, and `"2d4h"` to return `14400` instead of `187200`.

## Changes
- Added `"d": 86400` to the `_UNITS` mapping in `duration_utils.py`
- Added `test_days` — verifies `parse_duration("1d") == 86400`
- Added `test_days_combined` — verifies `parse_duration("2d4h") == 187200`
- All 9 tests pass (2 new + 7 existing)

## Testing
```bash
python -m unittest discover -s tests -v
# Ran 9 tests in 0.004s — OK
```

Fixes #1