### PR TITLE
fix: add days (d) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -1,12 +1,13 @@
-"""Parse human-friendly duration strings like '1h30m' into seconds."""
+"""Parse human-friendly duration strings like '1d2h30m' into seconds."""
 
 from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -20,6 +21,7 @@ def parse_duration(text: str) -> int:
 
     Examples:
         parse_duration("1h30m") -> 5400
+        parse_duration("1d")    -> 86400
         parse_duration("1w")    -> 604800
 
     Raises ValueError on empty or malformed input.

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -13,6 +13,12 @@ class ParseDuration(unittest.TestCase):
     def test_seconds(self):
         self.assertEqual(parse_duration("45s"), 45)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 


### PR DESCRIPTION
Fixes #1

## Problem
`parse_duration` silently drops the **days** (`d`) unit. The token regex already accepts `d` in `[wdhms]`, but `_UNITS` was missing the `d` key, causing day values to be ignored.

```python
parse_duration("1d")     # -> 0        (expected 86400)
parse_duration("2d4h")   # -> 14400    (expected 187200)
```

## Fix
- Added `"d": 86400` to `_UNITS` dict
- Added `test_days` and `test_days_combined` tests
- Updated docstring to show day example

## Verification
All 9 tests pass (7 existing + 2 new):
```
test_days ... ok
test_days_combined ... ok
```