### PR TITLE
fix: handle days unit in parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -7,6 +7,7 @@ import re
 # Seconds per unit. Supported: weeks, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("2d"), 172800)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("1d12h"), 129600)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
Fixes #1

The `parse_duration` function silently dropped the `d` (days) unit because `_UNITS` was missing the key `d: 86400`.

Changes:
- Added `"d": 86400` to `_UNITS` dict in `duration_utils.py`
- Added `test_days` and `test_days_combined` tests

All 9 tests pass.