### PR TITLE
Fix day duration parsing

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,8 +16,14 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
+
+    def test_combined_with_days(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
 
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- Add the missing `d` unit to the duration unit table.
- Add coverage for `1d` and `2d4h` parsing.

## Verification
- `py -m unittest -v` passes: 9 tests.

## Payment
- USDC on Base: `0x408Bd09b77dc354591D6d6c3254B48a517328634`

Closes #1