### PR TITLE
fix: add days (d) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -20,6 +21,7 @@ def parse_duration(text: str) -> int:
 
     Examples:
         parse_duration("1h30m") -> 5400
+        parse_duration("1d")    -> 86400
         parse_duration("1w")    -> 604800
 
     Raises ValueError on empty or malformed input.

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

The `d` (days) unit was matched by the token regex (`[wdhms]`) but was missing from the `_UNITS` mapping, causing `parse_duration` to silently drop day values.

**Before:**
```python
parse_duration("1d")     # -> 0
parse_duration("2d4h")   # -> 14400
```

**After:**
```python
parse_duration("1d")     # -> 86400
parse_duration("2d4h")   # -> 187200
```

### Changes
- Added `"d": 86400` to `_UNITS` dict
- Updated docstring with days example
- Added 2 test cases: `test_days` and `test_days_combined`

All 9 tests pass.

Fixes #1