### PR TITLE
Fix day duration parsing

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_days.py
+++ b/tests/test_days.py
@@ -3,4 +3,3 @@ from duration_utils import parse_duration
 class ParseDurationDays(unittest.TestCase):
   def test_days(self):
     self.assertEqual(parse_duration("1d"), 86400)
-    

--- a/tests/test_days.py
+++ b/tests/test_days.py
@@ -1,0 +1,6 @@
+import unittest
+from duration_utils import parse_duration
+class ParseDurationDays(unittest.TestCase):
+  def test_days(self):
+    self.assertEqual(parse_duration("1d"), 86400)
+    


### PR DESCRIPTION
## Summary
- add the missing `d` unit mapping so day durations count as 86,400 seconds
- - add unittest coverage for `parse_duration("1d")`
## Tests
- `python3 -m unittest discover -s tests`
- - `git diff --check origin/main..refs/remotes/hanuas/fix-parse-duration-days`
Fixes #1