### PR TITLE
fix: add support for 'd' (days) unit in parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -7,6 +7,7 @@ import re
 # Seconds per unit. Supported: weeks, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -19,6 +19,13 @@ class ParseDuration(unittest.TestCase):
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
+
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):
             parse_duration("abc")


### PR DESCRIPTION
/claim #1

Fixes the missing `d` (days) unit in `parse_duration` by adding `"d": 86400` to the `_UNITS` dictionary.

Also added regression tests for `1d` and `2d4h` in `tests/test_duration_utils.py` to ensure it works accurately and handles combined units correctly.

All 9 tests passed locally:
```
python3 -m unittest discover -s tests
.........
----------------------------------------------------------------------
Ran 9 tests in 0.000s

OK
```
