### PR TITLE
fix: add days (d) unit support to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -21,6 +22,7 @@ def parse_duration(text: str) -> int:
     Examples:
         parse_duration("1h30m") -> 5400
         parse_duration("1w")    -> 604800
+        parse_duration("1d")    -> 86400
 
     Raises ValueError on empty or malformed input.
     """

--- a/tests/test_days.py
+++ b/tests/test_days.py
@@ -1,0 +1,15 @@
+from duration_utils import parse_duration
+import unittest
+
+class TestDays(unittest.TestCase):
+    def test_one_day(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_with_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
+    def test_week_with_day(self):
+        self.assertEqual(parse_duration("1w1d"), 691200)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #1

## Fix
Added d unit (86400 seconds) to _UNITS dictionary. The token regex already matched d but the unit was missing, causing silent data loss.

## Test
Added 	est_days.py covering:
- 1d = 86400
- 2d4h = 187200
- 1w1d = 691200