### PR TITLE
fix: add missing d (days) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -7,6 +7,7 @@ import re
 # Seconds per unit. Supported: weeks, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -13,6 +13,12 @@ class ParseDuration(unittest.TestCase):
     def test_seconds(self):
         self.assertEqual(parse_duration("45s"), 45)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 


### PR DESCRIPTION
## Fix

The regex `(\d+)([wdhms])` accepted `d` but the `_UNITS` dict had no `d` entry,
causing `parse_duration("1d")` to silently return 0 instead of 86400.

## Changes
- Added `"d": 86400` to `_UNITS`
- Added test `test_days` and `test_days_combined`

## Verification
```
test_days ... ok
test_days_combined ... ok
9/9 tests passed
```

Fixes #1