### PR TITLE
fix: add days (d) unit support to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,18 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_multiple(self):
+        self.assertEqual(parse_duration("3d"), 259200)
+
+    def test_days_combined_with_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
+    def test_full_combined(self):
+        self.assertEqual(parse_duration("1w2d3h4m5s"), 788645)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

The `parse_duration` function was missing support for the days (d) unit, despite the regex pattern already matching it in [wdhms].

## Changes

- Added "d": 86400 to the _UNITS dictionary so that parse_duration("1d") correctly returns 86400
- Updated the comment to reflect the new supported units list
- Added 4 new test cases:
  - test_days: 1d -> 86400
  - test_days_multiple: 3d -> 259200
  - test_days_combined_with_hours: 2d4h -> 187200
  - test_full_combined: 1w2d3h4m5s -> 788645

All 11 tests pass.

Fixes #1