### PR TITLE
fix: add days (d) unit support to parse_duration (fixes #1)

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -19,6 +19,12 @@ class ParseDuration(unittest.TestCase):
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("1d12h"), 129600)
+
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):
             parse_duration("abc")


### PR DESCRIPTION
## Summary

The `parse_duration` function silently dropped the `d` (days) unit because the `_UNITS` dict was missing the entry, even though the regex `_TOKEN` already matched it.

## Changes
- Added `"d": 86400` to the `_UNITS` dict in `duration_utils.py`
- Updated comment to reflect days support
- Added tests: `test_days` and `test_days_combined`

## Verification
All 9 tests pass (7 original + 2 new).

Fixes #1