### PR TITLE
Fix parse_duration dropping the days (d) unit

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

`parse_duration` silently dropped the **days** (`d`) unit. The token regex `(\d+)([wdhms])` already accepted `d`, but `_UNITS` was missing the entry, so `"1d"` parsed without raising yet contributed 0 seconds.

### Before
```python
parse_duration("1d")    # -> 0       (expected 86400)
parse_duration("2d4h")  # -> 14400   (expected 187200)
```

### Fix
Add `"d": 86400` to `_UNITS` and update the supported-units comment.

### Tests
Added `test_days` and `test_days_combined`. Full suite: **9/9 passing**, no regressions (`w`, `h`, `m`, `s`, combined all still pass; `1w2d3h` -> 788400).

Fixes #1

/claim #1