### PR TITLE
fix: add days ("d") unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -20,6 +21,7 @@ def parse_duration(text: str) -> int:
 
     Examples:
         parse_duration("1h30m") -> 5400
+        parse_duration("1d")    -> 86400
         parse_duration("1w")    -> 604800
 
     Raises ValueError on empty or malformed input.

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Problem

The `parse_duration` function accepts `"d"` as valid input (the regex matches it), but silently ignores the day value because `_UNITS` is missing the `"d"` key.

- `parse_duration("1d")` returns **0** instead of **86400**
- `parse_duration("2d4h")` returns **14400** instead of **187200**

## Fix

- Added `"d": 86400` to the `_UNS` dict in `duration_utils.py`
- Added `test_days` and `test_days_combined` test cases

## Tests

All 9 tests pass:

```
test_combined ... ok
test_days ... ok
test_days_combined ... ok
test_empty_raises ... ok
test_hours ... ok
test_invalid_raises ... ok
test_minutes ... ok
test_seconds ... ok
test_weeks ... ok
```

Fixes #1