### PR TITLE
fix: parse_duration to handle 'd' (days) unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ from duration_utils import parse_duration
 
 parse_duration("1h30m")   # 5400
 parse_duration("1w")      # 604800
+parse_duration("1d")      # 86400
 ```
 
 Supported units: `w` (weeks), `d` (days), `h` (hours), `m` (minutes), `s` (seconds).

--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -21,6 +22,7 @@ def parse_duration(text: str) -> int:
     Examples:
         parse_duration("1h30m") -> 5400
         parse_duration("1w")    -> 604800
+        parse_duration("1d")    -> 86400
 
     Raises ValueError on empty or malformed input.
     """

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,14 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+        self.assertEqual(parse_duration("2d"), 172800)
+
+    def test_combined_with_days(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+        self.assertEqual(parse_duration("1d2h30m"), 95400)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
Fixes the bug where parse_duration drops the days (d) unit.

- Added 'd': 86400 to _UNITS dictionary
- Added tests for days unit (test_days, test_combined_with_days)
- Updated README.md and docstring with examples

Closes #1

/bounty $50