### PR TITLE
fix: add days (d) support to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -7,6 +7,7 @@ import re
 # Seconds per unit. Supported: weeks, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,8 +16,13 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
+        self.assertEqual(parse_duration("1d2h30m45s"), 95445)
 
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Fixes #1
/claim #1
Added the missing `d` (days) unit mapped to 86400 seconds in `_UNITS` and included corresponding unit tests.