### PR TITLE
fix: add missing days (d) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Fix

Adds the `d` (days) unit to `parse_duration()`. The regex already matched `d`, but the value was silently ignored.

## Changes
- `duration_utils.py`: Added `"d": 86400` to `_UNITS`
- `tests/test_duration_utils.py`: Added `test_days` and `test_days_combined` (9 tests, all pass)

## Verification
All 9 tests pass.

Closes #1