### PR TITLE
fix: add days (d) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

Fixes #1

The `d` (days) token was matched by the regex but missing from `_UNITS`, causing `parse_duration("1d")` to silently return `0` instead of `86400`.

## Changes

- Added `"d": 86400` to `_UNITS` in `duration_utils.py`
- Added `test_days` and `test_days_combined` tests covering the reported cases

## Tests

```
parse_duration("1d")   == 86400   ✅
parse_duration("2d4h") == 187200  ✅
```

All 9 tests pass.