### PR TITLE
fix: add missing 'd' (days) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -21,6 +22,7 @@ def parse_duration(text: str) -> int:
     Examples:
         parse_duration("1h30m") -> 5400
         parse_duration("1w")    -> 604800
+        parse_duration("1d")    -> 86400
 
     Raises ValueError on empty or malformed input.
     """

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

Fixes #1 — `parse_duration` was silently dropping the `d` (days) unit.

### Root Cause

The `_TOKEN` regex already accepted `d` as a valid unit character (`[wdhms]`), but the `_UNITS` mapping dict did not include `"d"`. This meant day tokens were consumed (no `ValueError` raised) but contributed nothing to the total.

### Fix

Added `"d": 86400` to `_UNITS`, so:

```python
parse_duration("1d")   # 86400  ✓
parse_duration("2d4h") # 187200 ✓
```

Also updated the leading comment in `_UNITS` to include "days" and added `parse_duration("1d") -> 86400` to the docstring examples.

### Tests Added

- `test_days` — `parse_duration("1d") == 86400`
- `test_days_combined` — `parse_duration("2d4h") == 187200`

All 9 tests pass.
