### PR TITLE
fix(#1): parse_duration drops the days (d) unit

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,8 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
+        self.assertEqual(parse_duration("2d4h"), 187200)
 
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Fixes #1

# Fix `parse_duration` dropping days (`d`) unit

## Description

This PR fixes a bug in `duration_utils.py` where the `parse_duration` function silently ignored the days (`d`) unit. The `d` unit is explicitly listed as supported in the README and tokenized properly, but its corresponding value in seconds (86400) was missing from the `_UNITS` mapping.

## Changes Made

- **Added `d` to `_UNITS` dictionary:** Mapped the `d` key to `86400` seconds in `duration_utils.py`.
- **Updated internal comments:** Documented that `days` are indeed supported in the source comment.
- **Added unit tests:** Added a `test_days` method to verify that `"1d"` yields `86400`, and updated `test_combined` to include cases parsing both days and hours (e.g., `"2d4h"` yields `187200`) in `tests/test_duration_utils.py`.

## Testing Instructions

The existing test suite has been updated. To verify the fix, run the unittest module:

```bash
python -m unittest discover -s tests
```

All tests should pass without any errors.

Closes #1