### PR TITLE
fix: add missing 'd' (days) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -18,9 +19,13 @@ _TOKEN = re.compile(r"(\d+)([wdhms])")
 def parse_duration(text: str) -> int:
     """Return the total number of seconds in a duration string.
 
+    Supported units: w (weeks), d (days), h (hours), m (minutes), s (seconds).
+
     Examples:
         parse_duration("1h30m") -> 5400
         parse_duration("1w")    -> 604800
+        parse_duration("1d")    -> 86400
+        parse_duration("2d4h")  -> 187200
 
     Raises ValueError on empty or malformed input.
     """

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_and_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

`parse_duration` accepted `d` in the token regex but _UNITS had no entry for it, so day values were silently discarded.

## Fix
- Added `'d': 86400` to `_UNITS`
- Updated docstring to list days as a supported unit
- Added `test_days` and `test_days_and_hours` to the test suite

## Verification
```python
parse_duration('1d')    # -> 86400 ✅
parse_duration('2d4h')  # -> 187200 ✅
```

Closes #1