### PR TITLE
Add day (d) unit support to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -19,6 +19,15 @@ class ParseDuration(unittest.TestCase):
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_multiple(self):
+        self.assertEqual(parse_duration("2d"), 172800)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("1d12h"), 129600)
+
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):
             parse_duration("abc")


### PR DESCRIPTION
Fixes #1

The `parse_duration` function was silently dropping the `d` (days) unit. The regex already matched `d`, but the `_UNITS` dictionary didn't include it, so `parse_duration(1d)` returned 0 instead of 86400.

**Changes:**
- Added `d: 86400` to the `_UNITS` dictionary in `duration_utils.py`
- Added 3 tests for the days unit (single day, multiple days, combined with hours)