### PR TITLE
fix: count days (d) unit in parse_duration (#1)

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -19,6 +19,12 @@ class ParseDuration(unittest.TestCase):
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):
             parse_duration("abc")


### PR DESCRIPTION
## What this does
Fixes #1 — `parse_duration` now counts the `d` (days) unit as 86400 seconds.

## Root cause
The token regex `(\d+)([wdhms])` already accepted `d`, so a string like `1d`
tokenized cleanly and passed the `consumed == len(text)` check — but `_UNITS`
had no `d` entry, so the value was silently added as `0`. That is why
`parse_duration("1d")` returned `0` instead of counting it.

## The fix
One line: add `"d": 86400` to `_UNITS` (and update the module comment).

## Testing
Added two regression tests matching the issue's exact reproduction:
- `parse_duration("1d") == 86400`
- `parse_duration("2d4h") == 187200`

Full suite (9 tests) passes:
```
python -m unittest discover -s tests
.........
Ran 9 tests in 0.000s
OK
```
No unrelated code reformatted; one concern per PR per CONTRIBUTING.
