### PR TITLE
fix: add missing 'd' (days) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -7,6 +7,7 @@ import re
 # Seconds per unit. Supported: weeks, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Fix

The 'd' (days) unit was accepted by the token regex but missing from the _UNITS dictionary, causing parse_duration to silently return 0 for day values.

### Changes
- Added 'd': 86400 to _UNITS dict
- Added test_days() and test_days_combined() tests

### Verification
All 9 tests pass:
```
test_days PASSED — parse_duration('1d') == 86400
test_days_combined PASSED — parse_duration('2d4h') == 187200
```

Closes #1