### PR TITLE
Fix parse_duration dropping the days (d) unit

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## What

`parse_duration` silently dropped the **days** (`d`) unit. The `_TOKEN` regex already accepted `d`, but `_UNITS` had no `d` key, so the matched value was never added.

## Fix

Add `d = 86400` seconds to `_UNITS` (and update the docstring comment to list days).

## Verification

Matches the issue's exact reproduction:

```python
parse_duration("1d")    # -> 86400   (was 0)
parse_duration("2d4h")  # -> 187200  (was 14400)
```

Malformed-input detection is unaffected (`consumed != len(text)` still raises). Added `test_days` and `test_days_combined`; full suite green (9/9).

Closes #1

/claim #1