### PR TITLE
fix: add days (d) unit support to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -20,6 +21,7 @@ def parse_duration(text: str) -> int:
 
     Examples:
         parse_duration("1h30m") -> 5400
+        parse_duration("1d")    -> 86400
         parse_duration("1w")    -> 604800
 
     Raises ValueError on empty or malformed input.

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

The `parse_duration` function's `_UNITS` dict was missing the `'d'` (days) unit, causing it to silently return 0 for day-based inputs like `'1d'` or `'2d4h'` instead of the correct values (86400 and 187200 respectively).

## Changes
- Added `'d': 86400` to the `_UNITS` dictionary
- Updated the module docstring to list days as a supported unit
- Added `parse_duration("1d") -> 86400` example to the function docstring
- Added `test_days` and `test_days_combined` test cases

## Verification
All 9 tests pass (7 existing + 2 new):

```
test_combined ... ok
test_days ... ok
test_days_combined ... ok
test_empty_raises ... ok
test_hours ... ok
test_invalid_raises ... ok
test_minutes ... ok
test_seconds ... ok
test_weeks ... ok
```

Fixes #1