### PR TITLE
fix: add days (d) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -21,6 +22,8 @@ def parse_duration(text: str) -> int:
     Examples:
         parse_duration("1h30m") -> 5400
         parse_duration("1w")    -> 604800
+        parse_duration("1d")    -> 86400
+        parse_duration("2d4h")  -> 187200
 
     Raises ValueError on empty or malformed input.
     """

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -19,6 +19,15 @@ class ParseDuration(unittest.TestCase):
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
+    def test_all_units(self):
+        self.assertEqual(parse_duration("1w2d3h4m5s"), 604800 + 172800 + 10800 + 240 + 5)
+
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):
             parse_duration("abc")


### PR DESCRIPTION
## Problem
`parse_duration` silently drops the `days` (`d`) unit. The token regex already accepts `d` in `[wdhms]`, but the `_UNITS` dict is missing the `d` entry — so `parse_duration('1d')` returns `0` instead of `86400`.

## Fix
- Added `"d": 86400` to the `_UNITS` dict
- Updated docstring with day examples
- Added 3 new tests:
  - `test_days`: `parse_duration('1d') == 86400`
  - `test_days_combined`: `parse_duration('2d4h') == 187200`
  - `test_all_units`: `parse_duration('1w2d3h4m5s')` covers every unit

## Tests
All 10 tests pass (7 existing + 3 new).

Closes #1