### PR TITLE
fix: add days (d) unit support to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -7,6 +7,7 @@ import re
 # Seconds per unit. Supported: weeks, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,8 +16,20 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_two(self):
+        self.assertEqual(parse_duration("2d"), 172800)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
+
+    def test_combined_days_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
+    def test_combined_days_hours_mixed(self):
+        self.assertEqual(parse_duration("1d12h"), 129600)
 
     def test_invalid_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Fixes parse_duration to correctly handle the 'd' (days) unit.

Before: parse_duration('1d') returned 0
After: parse_duration('1d') returns 86400

Closes #1