### PR TITLE
fix: add missing days (d) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_and_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

Fixes #1

`parse_duration` silently drops the `d` (days) unit. The README lists `d` as a supported unit, and the regex already accepts it (`[wdhms]`), but the `_UNITS` dictionary was missing `"d": 86400`, so the value was never added to the total.

### Before

```python
parse_duration("1d")     # -> 0        (expected 86400)
parse_duration("2d4h")   # -> 14400    (expected 187200)
```

### After

```python
parse_duration("1d")     # -> 86400    ✓
parse_duration("2d4h")   # -> 187200   ✓
parse_duration("1d30m")  # -> 88200    ✓
```

### Changes

1. **`duration_utils.py`**: Added `"d": 86400` to the `_UNITS` dictionary
2. **`tests/test_duration_utils.py`**: Added `test_days` and `test_days_and_hours` test cases

All 9 tests pass (7 existing + 2 new).