### PR TITLE
Fix: parse_duration drops the days (d) unit

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -21,6 +22,8 @@ def parse_duration(text: str) -> int:
     Examples:
         parse_duration("1h30m") -> 5400
         parse_duration("1w")    -> 604800
+        parse_duration("1d")    -> 86400
+        parse_duration("2d4h")  -> 187200
 
     Raises ValueError on empty or malformed input.
     """

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary

This PR fixes the bug where `parse_duration` silently drops the **days** (`d`) unit.

## Changes

- Added `"d": 86400` to the `_UNITS` dictionary in `duration_utils.py`
- Added `test_days` and `test_days_combined` tests to `test_duration_utils.py`

## Verification

All 9 tests pass:
```
test_days ... ok
test_days_combined ... ok
```

## Fixes

Fixes #1

/bounty $50