### PR TITLE
fix: add missing days (d) unit to parse_duration

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -15,6 +15,10 @@ class ParseDuration(unittest.TestCase):
 
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
 
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
@@ -30,3 +34,4 @@ class ParseDuration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
Fixes #1

`parse_duration` accepted the `d` token via the regex but `_UNITS` was
missing a `"d"` entry, so days silently contributed 0 seconds instead
of raising an error or being counted.

Added `"d": 86400` to `_UNITS` and two regression tests covering a
single day and a combined days+hours duration.