### PR TITLE
fix: parse_duration silently drops the days (d) unit

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -7,6 +7,7 @@ import re
 # Seconds per unit. Supported: weeks, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_days_combined(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
Closes #1.

## Problem
`parse_duration` documents `d` (days) as supported, and the token regex
`(\d+)([wdhms])` matches it — but `_UNITS` had no `"d"` entry, so a `d` token
passed validation yet added nothing to the total:

    parse_duration("1d")    # -> 0       (expected 86400)
    parse_duration("2d4h")  # -> 14400   (expected 187200)

## Fix
Add `"d": 86400` to `_UNITS`.

## Tests
Added `test_days` and `test_days_combined`; the full suite passes (9/9), and
malformed input still raises `ValueError`. Minimal, focused change — one concern.