### PR TITLE
fix: include days in duration parsing

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -20,6 +21,7 @@ def parse_duration(text: str) -> int:
 
     Examples:
         parse_duration("1h30m") -> 5400
+        parse_duration("1d")    -> 86400
         parse_duration("1w")    -> 604800
 
     Raises ValueError on empty or malformed input.

--- a/tests/test_duration_utils.py
+++ b/tests/test_duration_utils.py
@@ -16,6 +16,12 @@ class ParseDuration(unittest.TestCase):
     def test_weeks(self):
         self.assertEqual(parse_duration("1w"), 604800)
 
+    def test_days(self):
+        self.assertEqual(parse_duration("1d"), 86400)
+
+    def test_combined_days_and_hours(self):
+        self.assertEqual(parse_duration("2d4h"), 187200)
+
     def test_combined(self):
         self.assertEqual(parse_duration("1h30m"), 5400)
 


### PR DESCRIPTION
## Summary
- add the missing `d` unit to `parse_duration`
- document days in the supported unit comment and examples
- add regression coverage for `1d` and `2d4h`

## Testing
- python -m unittest discover -s tests

Closes #1