### PR TITLE
fix: add days (d) unit to _UNITS dictionary

### DIFF
--- a/duration_utils.py
+++ b/duration_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 
-# Seconds per unit. Supported: weeks, hours, minutes, seconds.
+# Seconds per unit. Supported: weeks, days, hours, minutes, seconds.
 _UNITS = {
     "w": 604800,
+    "d": 86400,
     "h": 3600,
     "m": 60,
     "s": 1,
@@ -21,6 +22,7 @@ def parse_duration(text: str) -> int:
     Examples:
         parse_duration("1h30m") -> 5400
         parse_duration("1w")    -> 604800
+        parse_duration("2d4h")  -> 187200
 
     Raises ValueError on empty or malformed input.
     """


### PR DESCRIPTION
## Fix

The `days` (`d`) unit was listed as supported in the README and accepted by the token regex, but was **missing** from the `_UNITS` dictionary, causing `parse_duration` to silently return 0 for inputs containing `d`.

## Changes

- Added `"d": 86400` to `_UNITS`
- Updated comment to list `days` as a supported unit
- Added `2d4h` example to docstring

## Verification

```python
from duration_utils import parse_duration

parse_duration("1d")     # -> 86400 ✓
parse_duration("2d4h")   # -> 187200 ✓
parse_duration("1h30m")  # -> 5400 ✓ (unchanged)
parse_duration("1w")     # -> 604800 ✓ (unchanged)
```

Fixes #1